### PR TITLE
Default Multiplicity and deal with circular references

### DIFF
--- a/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/Application.groovy
+++ b/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/Application.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/BootStrap.groovy
+++ b/grails-app/init/uk/ac/ox/softeng/maurodatamapper/plugins/BootStrap.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/XsdSchemaService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/XsdSchemaService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/XsdDefaultDataTypeProvider.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/XsdDefaultDataTypeProvider.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/exporter/XsdExporterProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/exporter/XsdExporterProviderService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/importer/XsdImporterProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/importer/XsdImporterProviderService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataClassProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataClassProfileProviderService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataElementProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataElementProfileProviderService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataModelProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataModelProfileProviderService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataTypeProfileProviderService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/profile/XsdDataTypeProfileProviderService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/BaseXsdImporterExporterProviderServiceSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/BaseXsdImporterExporterProviderServiceSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/Verification.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/Verification.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/exporter/XsdExporterProviderServiceSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/exporter/XsdExporterProviderServiceSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/importer/XsdImporterProviderServiceSpec.groovy
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/importer/XsdImporterProviderServiceSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/diff/evaluator/IgnoreNameAttributeDifferenceEvaluator.java
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/diff/evaluator/IgnoreNameAttributeDifferenceEvaluator.java
@@ -1,11 +1,11 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/diff/evaluator/IgnoreOrderDifferenceEvaluator.java
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/diff/evaluator/IgnoreOrderDifferenceEvaluator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/diff/selector/CustomElementSelector.java
+++ b/src/integration-test/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/diff/selector/CustomElementSelector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/MdmPluginXsdGrailsPlugin.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/MdmPluginXsdGrailsPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/XsdMetadata.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/XsdMetadata.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/importer/parameter/XsdImporterProviderServiceParameters.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/datamodel/provider/importer/parameter/XsdImporterProviderServiceParameters.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractAttributeGroup.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractAttributeGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractComplexType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractComplexType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractElement.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractGroup.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractSimpleType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AbstractSimpleType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/All.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/All.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Annotated.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Annotated.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Annotation.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Annotation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Any.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Any.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Appinfo.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Appinfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Attribute.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Attribute.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AttributeGroup.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AttributeGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AttributeGroupRef.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/AttributeGroupRef.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/BaseAttribute.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/BaseAttribute.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ComplexContent.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ComplexContent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ComplexRestrictionType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ComplexRestrictionType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ComplexType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ComplexType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/DerivationControl.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/DerivationControl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Documentation.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Documentation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Element.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Element.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ExplicitGroup.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ExplicitGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ExtensionType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ExtensionType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Facet.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Facet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Field.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Field.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/FormChoice.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/FormChoice.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Group.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Group.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/GroupRef.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/GroupRef.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Import.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Import.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Include.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Include.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Keybase.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Keybase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Keyref.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Keyref.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/List.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/List.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/LocalComplexType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/LocalComplexType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/LocalElement.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/LocalElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/LocalSimpleType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/LocalSimpleType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/NarrowMaxMin.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/NarrowMaxMin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/NoFixedFacet.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/NoFixedFacet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Notation.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Notation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/NumFacet.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/NumFacet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ObjectFactory.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/OpenAttrs.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/OpenAttrs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Pattern.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Pattern.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/RealGroup.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/RealGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Redefine.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Redefine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ReducedDerivationControl.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/ReducedDerivationControl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Restriction.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Restriction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/RestrictionType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/RestrictionType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Schema.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Schema.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Selector.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Selector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleContent.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleContent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleExplicitGroup.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleExplicitGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleExtensionType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleExtensionType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleRestrictionType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleRestrictionType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleType.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/SimpleType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/TotalDigits.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/TotalDigits.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/TypeDerivationControl.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/TypeDerivationControl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Union.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Union.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/WhiteSpace.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/WhiteSpace.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Wildcard.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/Wildcard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/package-info.java
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/org/w3/xmlschema/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/ExtensionCapable.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/ExtensionCapable.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/JaxbHandler.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/JaxbHandler.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/RestrictionCapable.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/RestrictionCapable.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/XsdNaming.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/utils/XsdNaming.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/AnnotatedWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/AnnotatedWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/AnnotationContentWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/AnnotationContentWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/BaseAttributeWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/BaseAttributeWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ComplexContentWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ComplexContentWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ComplexTypeWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ComplexTypeWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/DataStore.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/DataStore.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementBasedWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementBasedWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementWrapper.groovy
@@ -168,8 +168,12 @@ class ElementWrapper extends ElementBasedWrapper<AbstractElement> {
         wrappedElement.setName(createValidXsdName(dataElement.getLabel()))
         debug("Populating from {}", dataElement)
         wrappedElement.setAnnotation(createAnnotation(getAnnotation(), dataElement.getDescription()))
-        wrappedElement.setMinOccurs(BigInteger.valueOf(dataElement.getMinMultiplicity()))
-        wrappedElement.setMaxOccurs(dataElement.getMaxMultiplicity() == -1 ? "unbounded" : dataElement.getMaxMultiplicity().toString())
+        wrappedElement.setMinOccurs(BigInteger.valueOf(dataElement.getMinMultiplicity()?:0))
+        if(!dataElement.getMaxMultiplicity()) {
+            wrappedElement.setMaxOccurs("1")
+        } else {
+            wrappedElement.setMaxOccurs((dataElement.getMaxMultiplicity() == -1) ? "unbounded" : dataElement.getMaxMultiplicity().toString())
+        }
 
         DataType dataType = dataElement.getDataType()
         if (dataType.instanceOf(ReferenceType.class)) {

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ElementWrapper.groovy
@@ -178,8 +178,11 @@ class ElementWrapper extends ElementBasedWrapper<AbstractElement> {
         DataType dataType = dataElement.getDataType()
         if (dataType.instanceOf(ReferenceType.class)) {
             trace("Is a complexType element")
-            ComplexTypeWrapper complexTypeWrapper = schema.findOrCreateComplexType(((ReferenceType) dataType).getReferenceClass())
-            wrappedElement.setType(new QName(complexTypeWrapper.getName()))
+            // ComplexTypeWrapper complexTypeWrapper = schema.findOrCreateComplexType(((ReferenceType) dataType).getReferenceClass())
+            // Instead, we'll assume that this type is going to be created with the appropriate type name
+            DataClass referenceDataClass = ((ReferenceType) dataType).getReferenceClass()
+            String typeName = createValidTypeName(referenceDataClass.getLabel() + ' Type', referenceDataClass.getLastUpdated())
+            wrappedElement.setType(new QName(typeName))
         } else {
             trace("Is a simpleType element")
             SimpleTypeWrapper simpleTypeWrapper = schema.findOrCreateSimpleType(dataElement.getDataType())

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ExtensionTypeWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/ExtensionTypeWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/FacetWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/FacetWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/OpenAttrsWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/OpenAttrsWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/RestrictionKind.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/RestrictionKind.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/RestrictionWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/RestrictionWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/SchemaWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/SchemaWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/SchemaWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/SchemaWrapper.groovy
@@ -371,12 +371,7 @@ class SchemaWrapper extends OpenAttrsWrapper<Schema> {
         }
 
         debug("Adding in XSD elements")
-        addXsdElements(dataModel.getChildDataClasses().stream()
-                           .filter({dc ->
-                               dc.getMaxMultiplicity() != null &&
-                               dc.getMinMultiplicity() != null
-                           }
-                           ).collect(toSet()))
+        addXsdElements(dataModel.getChildDataClasses() as Set)
     }
 
 

--- a/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/SimpleTypeWrapper.groovy
+++ b/src/main/groovy/uk/ac/ox/softeng/maurodatamapper/plugins/xsd/wrapper/SimpleTypeWrapper.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/ox/softeng/metadatacatalogue/plugins/xsd/utils/XsdNamingTest.groovy
+++ b/src/test/groovy/ox/softeng/metadatacatalogue/plugins/xsd/utils/XsdNamingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
+ * Copyright 2020-2023 University of Oxford and Health and Social Care Information Centre, also known as NHS Digital
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Generate types for classes where multiplicity is not set, use 0 and 1 as default min / max respectively.
- When dealing with reference data types, don't risk looping forever; instead assume a type will be generated for the referenced class and just insert its  name